### PR TITLE
Command classes: remove unused import statements

### DIFF
--- a/src/main/java/mars/command/addCommand.java
+++ b/src/main/java/mars/command/addCommand.java
@@ -1,18 +1,13 @@
 package mars.command;
 
-import mars.Mars;
 import mars.marsException;
+import mars.storage.Storage;
 import mars.task.Deadline;
 import mars.task.Event;
-import mars.task.Task;
-import mars.task.Todo;
-
-import java.util.ArrayList;
-import java.util.Scanner;
-
 import mars.task.TaskList;
+import mars.task.Todo;
 import mars.ui.UI;
-import mars.storage.Storage;
+
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 

--- a/src/main/java/mars/command/byeCommand.java
+++ b/src/main/java/mars/command/byeCommand.java
@@ -1,12 +1,8 @@
 package mars.command;
 
 import mars.storage.Storage;
-import mars.task.Task;
 import mars.task.TaskList;
 import mars.ui.UI;
-
-import java.util.ArrayList;
-import java.util.Scanner;
 
 public class byeCommand extends Command {
     private static final String HORIZONTAL_LINE = "____________________________________________________________\n";

--- a/src/main/java/mars/command/deleteCommand.java
+++ b/src/main/java/mars/command/deleteCommand.java
@@ -1,13 +1,9 @@
 package mars.command;
 
+import mars.storage.Storage;
 import mars.task.Task;
-
-import java.util.ArrayList;
-import java.util.Scanner;
-
 import mars.task.TaskList;
 import mars.ui.UI;
-import mars.storage.Storage;
 
 
 public class deleteCommand extends Command{

--- a/src/main/java/mars/command/echoCommand.java
+++ b/src/main/java/mars/command/echoCommand.java
@@ -1,9 +1,8 @@
 package mars.command;
 
-import java.util.Scanner;
+import mars.storage.Storage;
 import mars.task.TaskList;
 import mars.ui.UI;
-import mars.storage.Storage;
 
 public class echoCommand extends Command{
     private static final String HORIZONTAL_LINE = "____________________________________________________________\n";

--- a/src/main/java/mars/command/listCommand.java
+++ b/src/main/java/mars/command/listCommand.java
@@ -5,8 +5,6 @@ import mars.task.Task;
 import mars.task.TaskList;
 import mars.ui.UI;
 
-import java.util.ArrayList;
-
 public class listCommand extends Command{
     private static final String HORIZONTAL_LINE = "____________________________________________________________\n";
 


### PR DESCRIPTION
Command child classes (e.g. addCommand, byeCommand, deleteCommand) have some unused import statements

These unused import statements across Command classes cause unnecessary extra lines of code.

Removing these unused import statements helps improve code readability, and therefore code quality.

Let's remove the unused import statements in this classes